### PR TITLE
Port Scallion to Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 
 val commonSettings = Seq(
-  version            := "0.5",
+  version            := "0.6",
   scalaVersion       := "3.0.1",
   crossScalaVersions := Seq("3.0.1"),
   organization       := "ch.epfl.lara",

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 
 val commonSettings = Seq(
   version            := "0.5",
-  scalaVersion       := "2.12.8",
-  crossScalaVersions := Seq("2.12.8", "2.13.1"),
+  scalaVersion       := "3.0.1",
+  crossScalaVersions := Seq("2.12.13", "2.13.4", "3.0.1"),
   organization       := "ch.epfl.lara",
   resolvers          += "bintray-epfl-lara" at "https://dl.bintray.com/epfl-lara/maven",
 )
@@ -29,8 +29,8 @@ lazy val scallion = project
     target in Compile in doc := baseDirectory.value / "docs",
 
     libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % "3.0.8" % "test",
-      "ch.epfl.lara" %% "silex" % "0.5" % "test",
+      "org.scalatest" %% "scalatest" % "3.2.9" % "test",
+      "ch.epfl.lara" %% "silex" % "0.6" % "test",
     ),
 
     bintrayOrganization := Some("epfl-lara"),
@@ -48,7 +48,7 @@ lazy val example = project
     commonSettings,
     name := "scallion-examples",
     scalaSource in Compile := baseDirectory.value,
-    libraryDependencies += "ch.epfl.lara" %% "silex" % "0.5",
+    libraryDependencies += "ch.epfl.lara" %% "silex" % "0.6",
   )
   .dependsOn(scallion)
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@
 val commonSettings = Seq(
   version            := "0.5",
   scalaVersion       := "3.0.1",
-  crossScalaVersions := Seq("2.12.13", "2.13.4", "3.0.1"),
+  crossScalaVersions := Seq("3.0.1"),
   organization       := "ch.epfl.lara",
   resolvers          += "bintray-epfl-lara" at "https://dl.bintray.com/epfl-lara/maven",
 )

--- a/example/calculator/Calculator.scala
+++ b/example/calculator/Calculator.scala
@@ -40,7 +40,7 @@ case class UnknownToken(content: String) extends Token {  // Unknowns.
 
 // The following object describes the tokens of the calculator language,
 // and provides methods to tokenize and display token sequences.
-object CalcLexer extends Lexers with CharRegExps {
+object CalcLexer extends Lexers with CharLexers {
 
   type Token = example.calculator.Token  // Tokens.
   type Position = Unit  // Positions. Ignored here.

--- a/example/json/JSON.scala
+++ b/example/json/JSON.scala
@@ -39,7 +39,7 @@ case class UnknownToken(content: String, range: (Int, Int)) extends Token
 
 // Then, we define the lexer.
 // The lexer converts sequences of characters into tokens.
-object JSONLexer extends Lexers with CharRegExps {
+object JSONLexer extends Lexers with CharLexers {
 
   type Token = example.json.Token
   type Position = Int

--- a/example/lambda/Lambda.scala
+++ b/example/lambda/Lambda.scala
@@ -33,7 +33,7 @@ case class UnknownToken(content: String) extends Token  // Unknown.
 
 // The following object describes the tokens of lambda calculus,
 // and provides methods to tokenize and display token sequences.
-object LambdaLexer extends Lexers with CharRegExps {
+object LambdaLexer extends Lexers with CharLexers {
 
   type Token = example.lambda.Token  // The type of tokens.
   type Position = Unit  // The type of positions. In this example, we ignore positions.

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.5.5

--- a/src/main/scala/scallion/Parsing.scala
+++ b/src/main/scala/scallion/Parsing.scala
@@ -1024,9 +1024,9 @@ trait Parsing { self: Syntaxes =>
 
       def epsilon[A](value: A): Tree[A] = {
         new Success(value) {
-          override val nullable: Option[A] = Some(value)
+          override val nullable: Option[A] = Some(this.value)
           override val first: HashSet[Kind] = HashSet()
-          override val syntax: Syntax[A] = self.epsilon(value)
+          override val syntax: Syntax[A] = self.epsilon(this.value)
         }
       }
     }

--- a/src/main/scala/scallion/Syntaxes.scala
+++ b/src/main/scala/scallion/Syntaxes.scala
@@ -19,6 +19,7 @@ import scala.annotation.implicitNotFound
 import scala.language.higherKinds
 import scala.util.Try
 import scala.collection.mutable.Map
+import scala.reflect.TypeTest
 
 /** Contains the definition of syntaxes. */
 trait Syntaxes {
@@ -300,7 +301,7 @@ trait Syntaxes {
       *
       * @group combinator
       */
-    def up[B >: A](implicit ev: Manifest[A]): Syntax[B] =
+    def up[B >: A](implicit ev: TypeTest[B, A]): Syntax[B] =
       this.map((x: A) => x, (y: B) => ev.unapply(y) match {
         case None => Seq()
         case Some(x) => Seq(x)

--- a/src/test/scala/scallion/LL1ParserTests.scala
+++ b/src/test/scala/scallion/LL1ParserTests.scala
@@ -16,6 +16,8 @@
 package scallion
 
 import org.scalatest._
+import flatspec._
+import matchers._
 
 import scallion._
 
@@ -36,11 +38,10 @@ object Tokens {
 }
 import Tokens._
 
-class ParserTests extends FlatSpec with Inside with Parsers {
+class ParserTests extends AnyFlatSpec with should.Matchers with Inside with Parsers {
 
   type Token = Tokens.Token
   type Kind = Tokens.TokenClass
-
   import Implicits._
 
   override def getKind(token: Token): TokenClass = token match {

--- a/src/test/scala/scallion/json/JSON.scala
+++ b/src/test/scala/scallion/json/JSON.scala
@@ -51,7 +51,7 @@ case class NumberValue(value: Double, range: (Int, Int)) extends Value
 case class StringValue(value: String, range: (Int, Int)) extends Value
 case class NullValue(range: (Int, Int)) extends Value
 
-object JSONLexer extends Lexers with CharRegExps {
+object JSONLexer extends Lexers with CharLexers {
 
   type Token = scallion.json.Token
   type Position = Int

--- a/src/test/scala/scallion/json/JSONParserTests.scala
+++ b/src/test/scala/scallion/json/JSONParserTests.scala
@@ -16,8 +16,10 @@
 package scallion.json
 
 import org.scalatest._
+import flatspec._
+import matchers._
 
-class JSONParserTests extends FlatSpec with Inside {
+class JSONParserTests extends AnyFlatSpec with should.Matchers with Inside {
 
   def parse(text: String): Option[Value] =
     JSONParser(JSONLexer(text.iterator)).getValue

--- a/src/test/scala/scallion/roman/RomanSyntaxTests.scala
+++ b/src/test/scala/scallion/roman/RomanSyntaxTests.scala
@@ -16,8 +16,10 @@
 package scallion.roman
 
 import org.scalatest._
+import flatspec._
+import matchers._
 
-class RomanSyntaxTests extends FlatSpec with Inside {
+class RomanSyntaxTests extends AnyFlatSpec with should.Matchers with Inside {
 
   import RomanSyntax._
 


### PR DESCRIPTION
This is a draft PR attempting to port Scallion to Scala 3. Currently, I just updated the dependencies on Silex and Scalatest to their latest available versions. I tried to port the code to Scala 3, but was stuck due to the slight differences with existential types. I tried replacing existential types by `Any`, but got stuck later on.